### PR TITLE
Api to get nodeId for key range

### DIFF
--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -766,11 +766,10 @@ message RenameTablesResponse {
     Ydb.Operations.Operation operation = 1;
 }
 
-// Describes nodes serves some key range
-// The first one is leader,
-// any other are folower (if present)
-message Nodes {
-    repeated uint32 nodes;
+// Describes nodes that serve shard key range
+// The first one is leader, the rest are followers (if present)
+message KeyRangeNodes {
+    repeated uint32 nodes = 1;
 }
 
 // Describe table with given path
@@ -787,7 +786,7 @@ message DescribeTableRequest {
     // Includes partition statistics (required include_table_statistics)
     bool include_partition_stats = 7;
     // Includes shard -> node id maping (required include_shard_key_bounds)
-    bool include_node_id_info = 8;
+    bool include_shard_nodes_info = 8;
 }
 
 message DescribeTableResponse {
@@ -832,9 +831,9 @@ message DescribeTableResult {
     bool temporary = 17;
     // Is table column or row oriented
     StoreType store_type = 18;
-    // NodeId where shards located
-    // Each Nodes element contains message describes shards serve key range before coresponding bound in the shard_key_bounds field in the same position
-    repeated Nodes node_ids = 19;
+    // Node ids where shards are located
+    // Each node_ids element contains node ids where a corresponding key range is located
+    repeated KeyRangeNodes node_ids = 19;
 }
 
 message Query {

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -766,6 +766,13 @@ message RenameTablesResponse {
     Ydb.Operations.Operation operation = 1;
 }
 
+// Describes nodes serves some key range
+// The first one is leader,
+// any other are folower (if present)
+message Nodes {
+    repeated uint32 nodes;
+}
+
 // Describe table with given path
 message DescribeTableRequest {
     // Session identifier
@@ -779,6 +786,8 @@ message DescribeTableRequest {
     bool include_table_stats = 6;
     // Includes partition statistics (required include_table_statistics)
     bool include_partition_stats = 7;
+    // Includes shard -> node id maping (required include_shard_key_bounds)
+    bool include_node_id_info = 8;
 }
 
 message DescribeTableResponse {
@@ -823,6 +832,9 @@ message DescribeTableResult {
     bool temporary = 17;
     // Is table column or row oriented
     StoreType store_type = 18;
+    // NodeId where shards located
+    // Each Nodes element contains message describes shards serve key range before coresponding bound in the shard_key_bounds field in the same position
+    repeated Nodes node_ids = 19;
 }
 
 message Query {

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -766,10 +766,9 @@ message RenameTablesResponse {
     Ydb.Operations.Operation operation = 1;
 }
 
-// Describes nodes that serve shard key range
-// The first one is leader, the rest are followers (if present)
+// Describes node that serve shard key range
 message KeyRangeNodes {
-    repeated uint32 nodes = 1;
+    uint32 leader = 1;
 }
 
 // Describe table with given path
@@ -832,7 +831,7 @@ message DescribeTableResult {
     // Is table column or row oriented
     StoreType store_type = 18;
     // Node ids where shards are located
-    // Each node_ids element contains node ids where a corresponding key range is located
+    // Each node_ids element contains node id where a corresponding key range is located
     repeated KeyRangeNodes node_ids = 19;
 }
 


### PR DESCRIPTION
Motivation:
Network is limited, we need to reduce amount of transfers between nodes.

One of problem:
Session actor has no knowledge about key range distribution (data shard locations). Which means  we have to transfer data between data shard and kqp executor  to perform read or write.

![motivation drawio](https://github.com/user-attachments/assets/a67c4f8e-fbcb-411a-a3fc-9d7591ff2246)


Workaround:
Provide estimation about keyRange -> nodeId distribution to use session (which means executor and other kqp components) created on the same node where located corresponding data shard.
